### PR TITLE
Avoid excess ampersand in pagination params

### DIFF
--- a/indigo/templates/indigo/includes/pagination.html
+++ b/indigo/templates/indigo/includes/pagination.html
@@ -2,7 +2,7 @@
   <ul class="pagination">
       {% if page.has_previous %}
         <li class="pagination__item pagination__item--active">
-        <a title="previous page" href="?{{ extra_params }}&amp;{{ parameter_name }}={{ page.previous_page_number }}">&laquo;</a>
+        <a title="previous page" href="?{{ extra_params }}{{ parameter_name }}={{ page.previous_page_number }}">&laquo;</a>
         </li>
       {% else %}
         <li class="pagination__item pagination__item--disabled"><span>&laquo;</span></li>
@@ -15,7 +15,7 @@
           </li>
         {% elif num %}
           <li class="pagination__item pagination__item--active">
-          <a href="?{{ extra_params }}&amp;{{ parameter_name }}={{ num }}">{{ num }}</a>
+          <a href="?{{ extra_params }}{{ parameter_name }}={{ num }}">{{ num }}</a>
           </li>
         {% else %}
           <span>...</span>
@@ -24,7 +24,7 @@
 
       {% if page.has_next %}
         <li class="pagination__item pagination__item--active">
-          <a title="next page" href="?{{ extra_params }}&amp;{{ parameter_name }}={{ page.next_page_number }}">&raquo;</a>
+        <a title="next page" href="?{{ extra_params }}{{ parameter_name }}={{ page.next_page_number }}">&raquo;</a>
         </li>
       {% else %}
       <li class="pagination__item pagination__item--disabled"><span>&raquo;</span></li>

--- a/indigo/templatetags/indigo.py
+++ b/indigo/templatetags/indigo.py
@@ -84,7 +84,7 @@ def indigo_pagination(page, parameter_name='page', extremes=2, arounds=3, params
         page.number, page.paginator.num_pages, extremes, arounds
     )
     return {
-        'extra_params': urlencode(extra_params),
+        'extra_params': urlencode(extra_params) + '&' if extra_params else '',
         'page_numbers': page_numbers,
         'page': page,
         'parameter_name': parameter_name,


### PR DESCRIPTION
If no extra params, do not include the extra ampersand
