### PR TITLE
Strip out Google Analytics etc for cookie compliance

### DIFF
--- a/indigo/static/indigo/js/main.js
+++ b/indigo/static/indigo/js/main.js
@@ -35,23 +35,17 @@ require.config({
 	baseUrl: fullAssetLocation,
 	paths: {
 		app: '../app'
-		,allsite: 'all-site.min'
 		//libaries
 		,jquery: globalSiteSpecificVars.pathToJquery
 		,underscore: '//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min'
 		,backbone: '//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.1.2/backbone-min'
 		,fastclick: 'fastclick'
-		,googleAnalyticsLib: 'googleAnalytics.min'
 		,owl: 'owl.carousel.min'
 		,jwplayer: 'jwplayer'
 		,handleBars: 'handlebars.min'
 		,typeAheadBundle:  'typeahead.bundle.min'
 	}
 	,shim:{
-		allsite: {
-			deps: ['jquery']
-			,exports: 'gen'
-		}
 		,underscore: {
 			exports: '_'
 		}
@@ -61,9 +55,6 @@ require.config({
 		},
 		modernizr: {
 			exports: 'Modernizr'
-		},
-		googleAnalyticsLib: {
-			exports: 'ga'
 		},
 		owl: {
 			deps: ['jquery']

--- a/indigo/templates/indigo/base.html
+++ b/indigo/templates/indigo/base.html
@@ -15,12 +15,6 @@
 
   {% block social_meta %}
     <!-- social meta -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@uclnews">
-    <meta name="twitter:title" content="UCL - London's Global University">
-    <meta name="twitter:description" content="UCL (University College London) is London's leading multidisciplinary university, with 8,000 staff and 25,000 students.">
-    <meta name="twitter:creator" content="@UCLWAMS">
-    <meta name="twitter:image:src" content="http://www.ucl.ac.uk/visual-identity/logos/standalone.png">
     <meta property="og:image" content="http://www.ucl.ac.uk/visual-identity/logos/standalone.png" />
     <meta property="og:title" content="UCL - London's Global University" />
     <meta property="og:url" content="http://www.ucl.ac.uk" />
@@ -37,7 +31,6 @@
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet">
     <link href="{% indigo_static 'css/screen.min.css' %}" media="screen, projection" rel="stylesheet" type="text/css" />
   {% endblock styles %}
-
 
   {% block favicons %}
     <link rel="shortcut icon" href="{% indigo_static 'images/favicon.ico' %}" />
@@ -64,7 +57,6 @@
       //set conditional assets for main.js
       var globalSiteSpecificVars = {
         pathToJquery: '{% indigo_static "js/lib/jquery-1.9.1.min" %}',
-        googleAnalyticsIdsArray: [] //specify array of site specific id's NOT UCL generic UA-943297-1
       }
       if (cuttingTheMustard) {
         globalSiteSpecificVars.pathToJquery = '{% indigo_static "js/lib/jquery-2.1.1.min" %}';

--- a/indigo/templates/indigo/includes/footer.html
+++ b/indigo/templates/indigo/includes/footer.html
@@ -1,30 +1,31 @@
 <footer class="footer wrapper">
   <div class="footer__inner clearfix">
     <article class="block block--col-1">
-      <h2 class="as-h5">UCL facilities</h2>
+      <h2 class="as-h5">Visit</h2>
       <ul class="footer__list list-unstyled">
-        <li class="footer__item"><a href="//www.ucl.ac.uk/departments/faculties">Faculties and departments</a></li>
-        <li class="footer__item"><a href="//www.ucl.ac.uk/library/">Library</a></li>
-        <li class="footer__item"><a href="//www.ucl.ac.uk/museums">Museums and Collections</a></li>
-        <li class="footer__item"><a href="//www.thebloomsbury.com/">UCL Bloomsbury Theatre</a></li>
+        <li class="footer__item"><a href="//www.ucl.ac.uk/bloomsbury-theatre">Bloomsbury Theatre and Studio</a></li>
+        <li class="footer__item"><a href="//www.ucl.ac.uk/lccos/library-culture-collections-and-open-science-lccos">Library, Museums and Collections</a></li>
+        <li class="footer__item"><a href="//www.ucl.ac.uk/maps">UCL Maps</a></li>
+        <li class="footer__item"><a href="//studentsunionucl.org/shop">UCL Shop</a></li>
+        <li class="footer__item"><a href="//www.ucl.ac.uk/about/contact-us">Contact UCL</a></li>
       </ul>
     </article>
     <article class="block block--col-2">
-      <h2 class="as-h5">UCL locations</h2>
+      <h2 class="as-h5">Students</h2>
       <ul class="footer__list list-unstyled">
-        <li class="footer__item"><a href="//www.ucl.ac.uk/maps">Maps and buildings</a></li>
-        <li class="footer__item"><a href="//www.ucl.ac.uk/london">UCL and London</a></li>
-        <li class="footer__item"><a href="//www.ucl.ac.uk/global">UCL Global</a></li>
+        <li class="footer__item"><a href="//www.ucl.ac.uk/accommodation">Accommodation</a></li>
+        <li class="footer__item"><a href="//www.ucl.ac.uk/students">Current Students</a></li>
+        <li class="footer__item"><a href="//moodle.ucl.ac.uk/">Moodle</a></li>
+        <li class="footer__item"><a href="//studentsunionucl.org/">Students' Union</a></li>
       </ul>
     </article>
     <article class="block block--col-3">
-      <h2 class="as-h5">Connect with UCL</h2>
+      <h2 class="as-h5">Staff</h2>
       <ul class="footer__list list-unstyled">
-        <li class="footer__item"><a href="//www.ucl.ac.uk/alumni">Alumni</a></li>
-        <li class="footer__item"><a href="//www.ucl.ac.uk/enterprise">Businesses</a></li>
-        <li class="footer__item"><a href="//www.ucl.ac.uk/media">Media Relations</a></li>
-        <li class="footer__item"><a href="//www.ucl.ac.uk/hr/jobs/">Jobs</a></li>
-        <li class="footer__item"><a href="//www.ucl.ac.uk/campaign">Give to UCL</a></li>
+        <li class="footer__item"><a href="//app.ucl.ac.uk/InsideUCL/">Inside UCL</a></li>
+        <li class="footer__item"><a href="//www.ucl.ac.uk/staff">Staff Intranet</a></li>
+        <li class="footer__item"><a href="//www.ucl.ac.uk/work-at-url">Work at UCL</a></li>
+        <li class="footer__item"><a href="//www.ucl.ac.uk/human-resources">Human Resources</a></li>
       </ul>
     </article>
     <hr class="clear">
@@ -33,12 +34,12 @@
     </ul>
     <ul class="list-inline footer__list list-unstyled list-inline--divided">
       <li class="text-muted small">Copyright © {% now "Y" %} UCL</li>
-      <li class="text-muted small"><a href="//www.ucl.ac.uk/disclaimer">Disclaimer</a></li>
+      <li class="text-muted small"><a href="//www.ucl.ac.uk/legal-services/disclaimer">Disclaimer</a></li>
       <li class="text-muted small"><a href="//www.ucl.ac.uk/foi">Freedom of Information</a></li>
       <li class="text-muted small"><a href="//www.ucl.ac.uk/accessibility">Accessibility</a></li>
-      <li class="text-muted small"><a href="//www.ucl.ac.uk/legal-services/privacy">Privacy and Cookies</a></li>
-      <li class="text-muted small"><a href="//www.ucl.ac.uk/procurement/suppliers/slavery-stmt">Slavery statement</a></li>
-      <li class="text-muted small"><a href="//www.ucl.ac.uk/contact-list">Contact Us</a></li>
+      <li class="text-muted small"><a href="//www.ucl.ac.uk/home/cookies-settings">Cookies</a></li>
+      <li class="text-muted small"><a href="//www.ucl.ac.uk/legal-services/privacy">Privacy</a></li>
+      <li class="text-muted small"><a href="//www.ucl.ac.uk/commercial-procurement/modern-day-slavery-statement">Slavery statement</a></li>
     </ul>
   </div>
 </footer>

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='indigo-django',
-    version='0.5.15',
+    version='0.5.16',
     packages=find_packages(),
     install_requires=['Django>=1.8', 'django-formset-js==0.4.3'],
     include_package_data=True,


### PR DESCRIPTION
Also updated the footer links to match UCL home page.

Requires removing some of the core UCL JS which might break sites using this.